### PR TITLE
Modify bat file so it accepts multiple files

### DIFF
--- a/Texture64.bat
+++ b/Texture64.bat
@@ -1,2 +1,6 @@
-java -jar "%~dp0Texture64.jar" %1
+FOR %%A IN (%*) DO (
+	java -jar "%~dp0Texture64.jar" %%A
+	move "%%~dpAout.rgba5551" "%%~dpnA.rgba5551"
+	move "%%~dpAout.rgba8888" "%%~dpnA.rgba8888"
+)
 pause


### PR DESCRIPTION
This makes it easy to convert many files at once. The output file is named using to the original file name.